### PR TITLE
Step 3 - Using docker internal virtual networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ volumes:
 1. Demonstrate app doesn't work (ask why, no more ports on host)
 1. Modify settings so apps can resolve eachother
 1. Demonstrate app now works
+1. Demonstrate no host ports used with `netstat -ntlp`
 
 ```docker-compose
 version: "3.8"

--- a/README.md
+++ b/README.md
@@ -61,3 +61,58 @@ volumes:
 ```
 
 ![Step 2 Diagram](notes-assets/step-2.png)
+
+# Step 3
+
+1. Show step 3 design
+1. Discuss how docker manages its own virtual networks
+1. Internal networks are only accessible by containers in a specific compose stack
+1. External networks are accessible by anything in the docker daemon or on the host
+1. Have to manually create external network `docker network create host-network`
+1. Internal networks created on `docker-compose up`
+1. Modify docker-compose
+1. Get IP of webapp using `docker inspect <id> | jq '.[0].NetworkSettings.Networks."host-network".IPAddress'`
+1. Demonstrate app doesn't work (ask why, no more ports on host)
+1. Modify settings so apps can resolve eachother
+1. Demonstrate app now works
+
+```docker-compose
+version: "3.8"
+services:
+  
+  webapp:
+    build:
+      context: ./webapp/DemoWebApp
+      dockerfile: Dockerfile
+    networks:
+      - host-network
+      - internal-network
+      
+  mongo:
+    container_name: mongo
+    image: mongo:latest
+    volumes: 
+      - mongodata:/data/db
+    networks:
+      - internal-network
+        
+  redis:
+    container_name: redis
+    image: redis:latest
+    volumes: 
+      - redisdata:/data
+    networks:
+      - internal-network
+    
+volumes:
+    mongodata:
+    redisdata:
+
+networks:
+  host-network:
+    external: true
+  internal-network:
+    external: false
+```
+
+![Step 3 Diagram](notes-assets/step-3.png)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,22 +1,36 @@
 version: "3.8"
 services:
+  
   webapp:
     build:
-      context: webapp/DemoWebApp
+      context: ./webapp/DemoWebApp
       dockerfile: Dockerfile
-    ports: ["8080:8080"]
-  mongo: 
+    networks:
+      - host-network
+      - internal-network
+      
+  mongo:
+    container_name: mongo
     image: mongo:latest
-    ports: ["27017:27017"]
     volumes: 
       - mongodata:/data/db
+    networks:
+      - internal-network
+        
   redis:
+    container_name: redis
     image: redis:latest
-    ports: ["6379:6379"]
     volumes: 
       - redisdata:/data
+    networks:
+      - internal-network
     
 volumes:
     mongodata:
     redisdata:
 
+networks:
+  host-network:
+    external: true
+  internal-network:
+    external: false

--- a/webapp/DemoWebApp/Notes/WebApplication/NotesWebApplicationExtensions.cs
+++ b/webapp/DemoWebApp/Notes/WebApplication/NotesWebApplicationExtensions.cs
@@ -13,9 +13,7 @@ public static class NotesWebApplicationExtensions
                 var option = await notesRepo.Get(id);
 
                 return option.HasSome ? Results.Ok(option.Value) : Results.NotFound();
-            })
-            .WithName("GetNotes")
-            .WithOpenApi();
+            });
 
         app.MapPost("/notes", async ([FromServices] IRepository<Note> notesRepo, [FromBody] Note note) =>
         {

--- a/webapp/DemoWebApp/appsettings.json
+++ b/webapp/DemoWebApp/appsettings.json
@@ -7,10 +7,10 @@
   },
   "AllowedHosts": "*",
   "RedisOptions": {
-    "Host": "172.17.0.1"
+    "Host": "redis"
   },
   "MongoOptions": {
-    "ConnectionString": "mongodb://172.17.0.1:27017",
+    "ConnectionString": "mongodb://mongo:27017",
     "DatabaseName": "DemoWebApp"
   }
 }


### PR DESCRIPTION
We don't want to have to worry about conflicts with the hosts' ports or have anything external accessing our services. So let's use an internal virtual network.